### PR TITLE
fix type hint for `CSRFProtectMiddleware`

### DIFF
--- a/starlette_wtf/csrf.py
+++ b/starlette_wtf/csrf.py
@@ -95,7 +95,7 @@ class CSRFProtectMiddleware:
     def __init__(self,
                  app: ASGIApp,
                  enabled: bool=DEFAULT_ENABLED,
-                 csrf_secret: Optional[ByteString]=DEFAULT_CSRF_SECRET,
+                 csrf_secret: Optional[str]=DEFAULT_CSRF_SECRET,
                  csrf_field_name: str=DEFAULT_CSRF_FIELD_NAME,
                  csrf_time_limit: int=DEFAULT_CSRF_TIME_LIMIT,
                  csrf_headers: List[str]=DEFAULT_CSRF_HEADERS,


### PR DESCRIPTION
Parameter `csrf_secret` of class `CSRFProtectMiddleware` should be of type `Optional[str]` instead of `Optional[ByteString]` as `generate_csrf` and `validate_csrf` take in `csrf_secret` as `str`. Passing a `ByteString` as `csrf_secret` to `CSRFProtectMiddleware` cause token validation to raise `BadSignature` exception, and `validate_csrf` to raise `ValidationError('The CSRF token is invalid.')`.